### PR TITLE
Add usagePlan for api keys

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -39,7 +39,13 @@ custom:
 provider:
   name: aws
   apiKeys:
-    - admin-${opt:stage}
+    - all:
+      - admin-${opt:stage}
+  usagePlan:
+    - all:
+        throttle:
+          burstLimit: 200
+          rateLimit: 1000
   runtime: nodejs8.10
   region: ${self:custom.region}
   timeout: 30


### PR DESCRIPTION
Fixes [this issue](https://github.com/serverless/serverless/issues/2450) with serverless. 

Adding these lines correctly created an API key and associated usage plan in AWS. I set the limits arbitrarily, but I doubt we'll ever need to go above this. 